### PR TITLE
fix BOTH bugs that lead to password errors around char 20 (in default charset)

### DIFF
--- a/pwmlib.py
+++ b/pwmlib.py
@@ -100,6 +100,7 @@ class PWM:
       password = ''
       count = 0;
       tkey = key # Copy of the master password so we don't interfere with it.
+      dat = data
       while len(password) < passwordLength and count < 1000:
           if count == 0:
               key = tkey

--- a/testpwmlib.py
+++ b/testpwmlib.py
@@ -17,5 +17,8 @@ class PWTest(unittest.TestCase):
     def test_64chars(self):
         res = self.pw.generatepassword('md5','asdf','passwordmaker.org'+''+'',False,1,64,self.pw.FULL_CHARSET,'','')
         self.assertEqual(res,'FRRHm)k+UyQiY~%Dj;h*FV[{:5X@EN5krPbfUlY7BRv12Dl.QJ=-]pF}UyDtCZ9#')
+    def test_64chars_hmac(self):
+        res = self.pw.generatepassword('hmac-rmd160','asdf','passwordmaker.org'+''+'',False,1,64,self.pw.FULL_CHARSET,'','')
+        self.assertEqual(res,'DBgLK[hHK{[e8nfH8/SI.Kz.(E}10$O-U2#f{jBWYT]b:&]vjDC3bBPQE*XN)\'5y')
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I guess the commit message says it all.
First bug: range(num, 0, -1) does NOT include 0, so the reversed array is also truncated.
=> missing the last character of the first round of hashing
Second bug: 'data' was being appended to itself, so the 'key' argument to the hash function got longer and longer. 
=> yielding totally different results starting at the second round of hashing
